### PR TITLE
Extend results with original URI to HTML when there are matches

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -14,6 +14,7 @@ module.exports = {
       ignored: false,
       whitelisted: false,
       matches_html: 0,
+      matches_uris: [],
       occurences_css: 0,
       pos_css: {}
     };

--- a/lib/html.js
+++ b/lib/html.js
@@ -176,7 +176,7 @@ module.exports = {
       if (regularResult) {
         document = cheerio.load(regularResult);
 
-        matchSelectorsInDocument(document, result);
+        matchSelectorsInDocument(document, context.uri, result);
         if (context.followLinks) { // look for links in document, add to queue
           queueLinks(document, queue, context);
         }
@@ -185,7 +185,7 @@ module.exports = {
       if (loggedInResult) {
         document = cheerio.load(loggedInResult);
 
-        matchSelectorsInDocument(document, result);
+        matchSelectorsInDocument(document, context.uri, result);
         if (context.followLinks) { // look for links in document, add to queue
           queueLinks(document, queue, context);
         }
@@ -297,9 +297,10 @@ module.exports = {
    *
    * @private
    * @param {Object} document HTML as Cheerio document.
+   * @param {string} uri Original URI to the html string.
    * @param {Object} result Result object.
    */
-  _matchSelectorsInDocument: function (document, result) {
+  _matchSelectorsInDocument: function (document, uri, result) {
     // Loop through selectors
     for (var selector in result.selectors) {
       // If current selector is whitelisted, skip.
@@ -328,6 +329,7 @@ module.exports = {
 
             // Add number of matches for selector to total matches
             result.selectors[oSelector].matches_html = result.selectors[oSelector].matches_html + len;
+            result.selectors[oSelector].matches_uris.push(uri);
           }
         } catch (error) {
           console.log(RED + 'Selector: "' +


### PR DESCRIPTION
Currently for each selector the total number of pages where the given selector has matches is stored in the results and displayed by default.

It would be useful to store the URIs to those pages along with the numbers. I wouldn't suggest including them in the default output, but if someone wants to override how the results are presented, why not let them use those URIs too?

My use case was that I wanted to know the list of pages where a particular selector was used. While answering this question is not really the core purpose of the module, it crawls those pages, counts them, so it might as well could take note of the URIs.